### PR TITLE
adding the JSON constant to escape single quotes

### DIFF
--- a/app/design/adminhtml/default/default/template/proxiblue_configgen.phtml
+++ b/app/design/adminhtml/default/default/template/proxiblue_configgen.phtml
@@ -15,7 +15,7 @@ $installer->startSetup();
 
 $config = new Mage_Core_Model_Config();
 
-$configItems = json_decode('<?php echo json_encode($this->getConfigItems());?>');
+$configItems = json_decode('<?php echo json_encode($this->getConfigItems(), JSON_HEX_APOS);?>');
 
 foreach ($configItems as $configItem) {
       $config->saveConfig($configItem->path, $configItem->value, $configItem->scope, $configItem->scope_id);


### PR DESCRIPTION
![singlequoteissue](https://cloud.githubusercontent.com/assets/1429634/10316224/3304bd5e-6c2c-11e5-96b6-0f330be888a9.png)
Some of the config values in our system are text. Some of these text have single quote in them which were not being escaped. I added JSON_HEX_APOS option to fix the issue as discussed in the following stackoverflow article

http://stackoverflow.com/questions/17926354/php-json-encode-jquery-parsejson-single-quote-issue
